### PR TITLE
Add PHP extensions requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,8 @@
     "name": "rewrewby/php-rtorrent-client",
     "description": "PHP XMLRPC client for rTorrent",
     "require": {
+        "ext-curl": "*",
+        "ext-xmlrpc": "*",
         "guzzlehttp/guzzle": "^6.2"
     },
     "license": "BSD",


### PR DESCRIPTION
If the extensions are required, it should be present on the `composer.json` file.

BTW, it should be better to not have any `composer.lock` on a library project.